### PR TITLE
Add basic sports events screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
@@ -1,49 +1,18 @@
 package net.score.volley.demo
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
+import androidx.compose.runtime.Composable
 import org.jetbrains.compose.ui.tooling.preview.Preview
-
-import demo.composeapp.generated.resources.Res
-import demo.composeapp.generated.resources.compose_multiplatform
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer)
-                .safeContentPadding()
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
-            }
-        }
+        val events = listOf(
+            SportEvent("Morning Run", "Beginner", "08:00", 5),
+            SportEvent("Evening Soccer", "Intermediate", "18:30", 10),
+            SportEvent("Tennis Match", "Advanced", "20:00", 4),
+        )
+        SportsEventsScreen(events)
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportEvent.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportEvent.kt
@@ -1,0 +1,11 @@
+package net.score.volley.demo
+
+/**
+ * Represents a sports event that users can join.
+ */
+data class SportEvent(
+    val name: String,
+    val playerLevel: String,
+    val startTime: String,
+    val requiredParticipants: Int,
+)

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportsEventsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportsEventsScreen.kt
@@ -1,0 +1,39 @@
+package net.score.volley.demo
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SportsEventsScreen(
+    events: List<SportEvent>,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        items(events) { event ->
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(event.name, style = MaterialTheme.typography.titleMedium)
+                    Spacer(Modifier.height(4.dp))
+                    Text("Level: ${event.playerLevel}")
+                    Text("Starts: ${event.startTime}")
+                    Text("Needed participants: ${event.requiredParticipants}")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show a list of sports events in the demo app
- add SportEvent model and screen to render events

## Testing
- `./gradlew :composeApp:compileKotlinMetadata`
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d1abd6b883258dd32985b9d74e94