### PR TITLE
Add repository, use case, and view model layers

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
@@ -2,17 +2,22 @@ package net.score.volley.demo
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import net.score.volley.demo.data.InMemorySportEventRepository
+import net.score.volley.demo.domain.GetSportEventsUseCase
+import net.score.volley.demo.presentation.SportsEventsViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        val events = listOf(
-            SportEvent("Morning Run", "Beginner", "08:00", 5),
-            SportEvent("Evening Soccer", "Intermediate", "18:30", 10),
-            SportEvent("Tennis Match", "Advanced", "20:00", 4),
-        )
+        val repository = remember { InMemorySportEventRepository() }
+        val useCase = remember { GetSportEventsUseCase(repository) }
+        val viewModel = remember { SportsEventsViewModel(useCase) }
+        val events by viewModel.events.collectAsState()
         SportsEventsScreen(events)
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/data/InMemorySportEventRepository.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/data/InMemorySportEventRepository.kt
@@ -1,0 +1,16 @@
+package net.score.volley.demo.data
+
+import net.score.volley.demo.SportEvent
+
+/**
+ * Simple in-memory implementation of [SportEventRepository].
+ */
+class InMemorySportEventRepository : SportEventRepository {
+    private val events = listOf(
+        SportEvent("Morning Run", "Beginner", "08:00", 5),
+        SportEvent("Evening Soccer", "Intermediate", "18:30", 10),
+        SportEvent("Tennis Match", "Advanced", "20:00", 4),
+    )
+
+    override fun getEvents(): List<SportEvent> = events
+}

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/data/SportEventRepository.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/data/SportEventRepository.kt
@@ -1,0 +1,10 @@
+package net.score.volley.demo.data
+
+import net.score.volley.demo.SportEvent
+
+/**
+ * Repository for accessing [SportEvent]s.
+ */
+interface SportEventRepository {
+    fun getEvents(): List<SportEvent>
+}

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/domain/GetSportEventsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/domain/GetSportEventsUseCase.kt
@@ -1,0 +1,13 @@
+package net.score.volley.demo.domain
+
+import net.score.volley.demo.SportEvent
+import net.score.volley.demo.data.SportEventRepository
+
+/**
+ * Use case that retrieves sports events from the repository.
+ */
+class GetSportEventsUseCase(
+    private val repository: SportEventRepository,
+) {
+    operator fun invoke(): List<SportEvent> = repository.getEvents()
+}

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/presentation/SportsEventsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/presentation/SportsEventsViewModel.kt
@@ -1,0 +1,24 @@
+package net.score.volley.demo.presentation
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import net.score.volley.demo.SportEvent
+import net.score.volley.demo.domain.GetSportEventsUseCase
+
+/**
+ * ViewModel that exposes sports events for the UI.
+ */
+class SportsEventsViewModel(
+    private val getSportEventsUseCase: GetSportEventsUseCase,
+) {
+    private val _events = MutableStateFlow<List<SportEvent>>(emptyList())
+    val events: StateFlow<List<SportEvent>> = _events
+
+    init {
+        loadEvents()
+    }
+
+    private fun loadEvents() {
+        _events.value = getSportEventsUseCase()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SportEventRepository` abstraction with `InMemorySportEventRepository`
- Introduce `GetSportEventsUseCase` to fetch events from repository
- Add `SportsEventsViewModel` exposing events as a `StateFlow`
- Update `App` composable to use new architecture

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3154519b48325821bd435a226ba96