### PR TITLE
Use Voyager navigation for sport event details

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -64,6 +64,7 @@ kotlin {
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
+            implementation(libs.voyager.navigator)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
@@ -2,22 +2,13 @@ package net.score.volley.demo
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import net.score.volley.demo.data.InMemorySportEventRepository
-import net.score.volley.demo.domain.GetSportEventsUseCase
-import net.score.volley.demo.presentation.SportsEventsViewModel
+import cafe.adriel.voyager.navigator.Navigator
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        val repository = remember { InMemorySportEventRepository() }
-        val useCase = remember { GetSportEventsUseCase(repository) }
-        val viewModel = remember { SportsEventsViewModel(useCase) }
-        val events by viewModel.events.collectAsState()
-        SportsEventsScreen(events)
+        Navigator(SportsEventsScreen)
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportEventDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportEventDetailsScreen.kt
@@ -1,0 +1,34 @@
+package net.score.volley.demo
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+
+data class SportEventDetailsScreen(val event: SportEvent) : Screen {
+    @Composable
+    override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Text(event.name, style = MaterialTheme.typography.titleLarge)
+            Spacer(Modifier.height(8.dp))
+            Text("Level: ${'$'}{event.playerLevel}")
+            Text("Starts: ${'$'}{event.startTime}")
+            Text("Needed participants: ${'$'}{event.requiredParticipants}")
+            Spacer(Modifier.height(24.dp))
+            Button(onClick = { navigator.pop() }) {
+                Text("Back")
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportsEventsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportsEventsScreen.kt
@@ -1,37 +1,49 @@
 package net.score.volley.demo
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.navigator.LocalNavigator
+import net.score.volley.demo.data.InMemorySportEventRepository
+import net.score.volley.demo.domain.GetSportEventsUseCase
+import net.score.volley.demo.presentation.SportsEventsViewModel
 
-@Composable
-fun SportsEventsScreen(
-    events: List<SportEvent>,
-    modifier: Modifier = Modifier,
-) {
-    LazyColumn(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp)
-    ) {
-        items(events) { event ->
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-            ) {
-                Column(modifier = Modifier.padding(16.dp)) {
-                    Text(event.name, style = MaterialTheme.typography.titleMedium)
-                    Spacer(Modifier.height(4.dp))
-                    Text("Level: ${event.playerLevel}")
-                    Text("Starts: ${event.startTime}")
-                    Text("Needed participants: ${event.requiredParticipants}")
+object SportsEventsScreen : Screen {
+    @Composable
+    override fun Content() {
+        val repository = remember { InMemorySportEventRepository() }
+        val useCase = remember { GetSportEventsUseCase(repository) }
+        val viewModel = remember { SportsEventsViewModel(useCase) }
+        val events by viewModel.events.collectAsState()
+        val navigator = LocalNavigator.currentOrThrow
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            items(events) { event ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp)
+                        .clickable { navigator.push(SportEventDetailsScreen(event)) }
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Text(event.name, style = MaterialTheme.typography.titleMedium)
+                        Spacer(Modifier.height(4.dp))
+                        Text("Level: ${'$'}{event.playerLevel}")
+                        Text("Starts: ${'$'}{event.startTime}")
+                        Text("Needed participants: ${'$'}{event.requiredParticipants}")
+                    }
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ androidx-testExt = "1.2.1"
 composeMultiplatform = "1.8.2"
 junit = "4.13.2"
 kotlin = "2.2.0"
+voyager = "1.0.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -24,6 +25,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Add Voyager navigation dependency
- Convert events list and detail views into Voyager `Screen`s
- Initialize app with Voyager `Navigator` for screen transitions

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31793ac7083258afb76055f9846cc