### PR TITLE
Add bottom navigation with profile and events tabs

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -65,6 +65,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(libs.voyager.navigator)
+            implementation(libs.voyager.tab.navigator)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
@@ -1,14 +1,29 @@
 package net.score.volley.demo
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
-import cafe.adriel.voyager.navigator.Navigator
+import cafe.adriel.voyager.navigator.tab.CurrentTab
+import cafe.adriel.voyager.navigator.tab.TabNavigationItem
+import cafe.adriel.voyager.navigator.tab.TabNavigator
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        Navigator(SportsEventsScreen)
+        TabNavigator(SportsEventsTab) {
+            Scaffold(
+                bottomBar = {
+                    NavigationBar {
+                        TabNavigationItem(SportsEventsTab)
+                        TabNavigationItem(ProfileTab)
+                    }
+                }
+            ) {
+                CurrentTab()
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/ProfileTab.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/ProfileTab.kt
@@ -1,0 +1,34 @@
+package net.score.volley.demo
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import cafe.adriel.voyager.navigator.tab.Tab
+import cafe.adriel.voyager.navigator.tab.TabOptions
+
+object ProfileTab : Tab {
+    override val options: TabOptions
+        @Composable
+        get() {
+            val icon = rememberVectorPainter(Icons.Filled.Person)
+            return TabOptions(
+                index = 1u,
+                title = "Мой профиль",
+                icon = icon
+            )
+        }
+
+    @Composable
+    override fun Content() {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("Мой профиль")
+        }
+    }
+}
+

--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportsEventsTab.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/SportsEventsTab.kt
@@ -4,20 +4,35 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.List
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
+import cafe.adriel.voyager.navigator.tab.Tab
+import cafe.adriel.voyager.navigator.tab.TabOptions
 import net.score.volley.demo.data.InMemorySportEventRepository
 import net.score.volley.demo.domain.GetSportEventsUseCase
 import net.score.volley.demo.presentation.SportsEventsViewModel
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 
-object SportsEventsScreen : Screen {
+object SportsEventsTab : Tab {
+    override val options: TabOptions
+        @Composable
+        get() {
+            val icon = rememberVectorPainter(Icons.Filled.List)
+            return TabOptions(
+                index = 0u,
+                title = "Мои события",
+                icon = icon
+            )
+        }
+
     @Composable
     override fun Content() {
         val repository = remember { InMemorySportEventRepository() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
+voyager-tab-navigator = { module = "cafe.adriel.voyager:voyager-tab-navigator", version.ref = "voyager" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- introduce Voyager tab navigator dependency
- add profile and sports events tabs with bottom navigation

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f20c41448325ba8f01ba0b4a1739