### PR TITLE
fix: apply system bars padding

### DIFF
--- a/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
+++ b/composeApp/src/commonMain/kotlin/net/score/volley/demo/App.kt
@@ -1,9 +1,12 @@
 package net.score.volley.demo
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.navigator.tab.CurrentTab
 import cafe.adriel.voyager.navigator.tab.TabNavigator
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -21,8 +24,10 @@ fun App() {
                         TabNavigationItem(ProfileTab)
                     }
                 },
-            ) {
-                CurrentTab()
+            ) { paddingValues ->
+                Box(modifier = Modifier.padding(paddingValues)) {
+                    CurrentTab()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent screens from overlapping the status bar by applying Scaffold padding

## Testing
- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck detekt`
- `./gradlew test`
- `./gradlew :composeApp:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68a4285f39188325bc1c3df96c9f1b57