### PR TITLE
fix: include compose ui dependency for web wasm target

### DIFF
--- a/app-web/build.gradle.kts
+++ b/app-web/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
     sourceSets {
         val wasmJsMain by getting {
             dependencies {
+                implementation(compose.ui)
                 implementation(project(":shared:app"))
             }
         }

--- a/app-web/src/wasmJsMain/kotlin/Main.kt
+++ b/app-web/src/wasmJsMain/kotlin/Main.kt
@@ -1,6 +1,8 @@
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
 import net.scoretogether.shared.app.app
 
+@OptIn(ExperimentalComposeUiApi::class)
 fun main() {
     CanvasBasedWindow("App") { app() }
 }


### PR DESCRIPTION
## Summary
- add compose.ui dependency for wasm web module
- opt in to ExperimentalComposeUiApi in web entry point

## Testing
- `./gradlew :app-web:compileKotlinWasmJs --console=plain`
- `./gradlew ktlintCheck detekt --console=plain` *(fails: Expected newline before '.' in app-android/build.gradle.kts)*
- `./gradlew test --console=plain`
- `./gradlew :app-android:assembleDebug --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68a52cb1015c8325a12bf0789c19fd41