### PR TITLE
feat: add shared app theme and bars

### DIFF
--- a/shared/app/build.gradle.kts
+++ b/shared/app/build.gradle.kts
@@ -23,13 +23,24 @@ kotlin {
                 implementation(project(":shared:di"))
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }
 
 android {
     namespace = "net.scoretogether.shared.app"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    compileSdk =
+        libs.versions.android.compileSdk
+            .get()
+            .toInt()
     defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
     }
 }

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/App.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/App.kt
@@ -1,8 +1,36 @@
 package net.scoretogether.shared.app
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import net.scoretogether.shared.app.ui.components.AppBottomBar
+import net.scoretogether.shared.app.ui.components.AppBottomBarItem
+import net.scoretogether.shared.app.ui.components.AppTopBar
+import net.scoretogether.shared.app.ui.theme.AppTheme
 
 @Composable
 fun app() {
-    // TODO implement app UI
+    AppTheme {
+        Scaffold(
+            topBar = { AppTopBar(title = "ScoreTogether") },
+            bottomBar = {
+                AppBottomBar(
+                    items =
+                        listOf(
+                            AppBottomBarItem(label = "Home", icon = { Text("\uD83C\uDFE0") }),
+                            AppBottomBarItem(label = "Settings", icon = { Text("\u2699\uFE0F") }),
+                        ),
+                    selectedIndex = 0,
+                    onItemSelected = {},
+                )
+            },
+        ) { innerPadding ->
+            Box(modifier = Modifier.padding(innerPadding)) {
+                // TODO implement app UI
+            }
+        }
+    }
 }

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/ui/components/AppBottomBar.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/ui/components/AppBottomBar.kt
@@ -1,0 +1,33 @@
+@file:Suppress("FunctionName")
+
+package net.scoretogether.shared.app.ui.components
+
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AppBottomBar(
+    items: List<AppBottomBarItem>,
+    selectedIndex: Int,
+    onItemSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    NavigationBar(modifier = modifier) {
+        items.forEachIndexed { index, item ->
+            NavigationBarItem(
+                selected = index == selectedIndex,
+                onClick = { onItemSelected(index) },
+                icon = { item.icon() },
+                label = { Text(item.label) },
+            )
+        }
+    }
+}
+
+data class AppBottomBarItem(
+    val label: String,
+    val icon: @Composable () -> Unit,
+)

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/ui/components/AppTopBar.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/ui/components/AppTopBar.kt
@@ -1,0 +1,33 @@
+@file:Suppress("FunctionName")
+
+package net.scoretogether.shared.app.ui.components
+
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    onNavigationClick: (() -> Unit)? = null,
+    navigationIcon: @Composable (() -> Unit)? = null,
+    actions: @Composable () -> Unit = {},
+) {
+    CenterAlignedTopAppBar(
+        title = { Text(text = title) },
+        modifier = modifier,
+        navigationIcon = {
+            if (onNavigationClick != null && navigationIcon != null) {
+                IconButton(onClick = onNavigationClick) {
+                    navigationIcon()
+                }
+            }
+        },
+        actions = { actions() },
+    )
+}

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/ui/theme/AppTheme.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/ui/theme/AppTheme.kt
@@ -1,0 +1,26 @@
+@file:Suppress("FunctionName")
+
+package net.scoretogether.shared.app.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+@Composable
+fun AppTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    val colorScheme = if (useDarkTheme) DarkColors else LightColors
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        content = content,
+    )
+}
+
+private val LightColors = lightColorScheme()
+
+private val DarkColors = darkColorScheme()

--- a/shared/app/src/commonTest/kotlin/net/scoretogether/shared/app/ui/components/AppBottomBarItemTest.kt
+++ b/shared/app/src/commonTest/kotlin/net/scoretogether/shared/app/ui/components/AppBottomBarItemTest.kt
@@ -1,0 +1,12 @@
+package net.scoretogether.shared.app.ui.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppBottomBarItemTest {
+    @Test
+    fun itemStoresLabel() {
+        val item = AppBottomBarItem(label = "Home", icon = {})
+        assertEquals("Home", item.label)
+    }
+}


### PR DESCRIPTION
## Summary
- add AppTheme with light and dark color schemes
- introduce AppTopBar and AppBottomBar components
- wrap app entry with sample theme and bars
- add simple unit test for bottom bar item

## Testing
- `./gradlew ktlintCheck detekt`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a545ec72e8832596ce15895b85cd70