### PR TITLE
Add shared Koin DI and platform initialization

### DIFF
--- a/app-android/build.gradle.kts
+++ b/app-android/build.gradle.kts
@@ -15,6 +15,8 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(project(":shared:app"))
+            implementation(project(":shared:di"))
+            implementation(libs.koin.core)
             implementation(libs.androidx.activity.compose)
         }
     }
@@ -22,12 +24,21 @@ kotlin {
 
 android {
     namespace = "net.scoretogether.app.android"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    compileSdk =
+        libs.versions.android.compileSdk
+            .get()
+            .toInt()
 
     defaultConfig {
         applicationId = "net.scoretogether.app.android"
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
+        minSdk =
+            libs.versions.android.minSdk
+                .get()
+                .toInt()
+        targetSdk =
+            libs.versions.android.targetSdk
+                .get()
+                .toInt()
         versionCode = 1
         versionName = "1.0"
     }

--- a/app-android/src/androidMain/AndroidManifest.xml
+++ b/app-android/src/androidMain/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest package="net.scoretogether.app.android" xmlns:android="http://schemas.android.com/apk/res/android">
-    <application android:label="AppAndroid">
+    <application
+        android:name=".AndroidApp"
+        android:label="AppAndroid">
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app-android/src/androidMain/kotlin/net/scoretogether/app/android/AndroidApp.kt
+++ b/app-android/src/androidMain/kotlin/net/scoretogether/app/android/AndroidApp.kt
@@ -1,0 +1,14 @@
+package net.scoretogether.app.android
+
+import android.app.Application
+import net.scoretogether.shared.di.initKoin
+import org.koin.dsl.module
+
+private val platformModule = module { }
+
+class AndroidApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        initKoin(platformModule)
+    }
+}

--- a/app-ios/build.gradle.kts
+++ b/app-ios/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":shared:app"))
+                implementation(project(":shared:di"))
             }
         }
     }

--- a/app-ios/src/iosMain/kotlin/net/scoretogether/app/ios/Main.kt
+++ b/app-ios/src/iosMain/kotlin/net/scoretogether/app/ios/Main.kt
@@ -1,0 +1,15 @@
+package net.scoretogether.app.ios
+
+import androidx.compose.ui.window.ComposeUIViewController
+import net.scoretogether.shared.app.app
+import net.scoretogether.shared.di.initKoin
+import org.koin.dsl.module
+import platform.UIKit.UIViewController
+
+private val platformModule = module { }
+
+@Suppress("FunctionName")
+fun MainViewController(): UIViewController {
+    initKoin(platformModule)
+    return ComposeUIViewController { app() }
+}

--- a/app-web/build.gradle.kts
+++ b/app-web/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
             dependencies {
                 implementation(compose.ui)
                 implementation(project(":shared:app"))
+                implementation(project(":shared:di"))
             }
         }
     }

--- a/app-web/src/wasmJsMain/kotlin/Main.kt
+++ b/app-web/src/wasmJsMain/kotlin/Main.kt
@@ -1,8 +1,13 @@
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
 import net.scoretogether.shared.app.app
+import net.scoretogether.shared.di.initKoin
+import org.koin.dsl.module
+
+private val platformModule = module { }
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {
+    initKoin(platformModule)
     CanvasBasedWindow("App") { app() }
 }

--- a/shared/di/src/commonMain/kotlin/net/scoretogether/shared/di/Koin.kt
+++ b/shared/di/src/commonMain/kotlin/net/scoretogether/shared/di/Koin.kt
@@ -1,0 +1,27 @@
+package net.scoretogether.shared.di
+
+import org.koin.core.context.startKoin
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+/**
+ * Koin modules for shared code.
+ */
+val networkModule = module { }
+val dbModule = module { }
+val repositoryModule = module { }
+val useCaseModule = module { }
+
+/**
+ * Initialize Koin with shared modules and [platformModules].
+ */
+fun initKoin(vararg platformModules: Module) =
+    startKoin {
+        modules(
+            networkModule,
+            dbModule,
+            repositoryModule,
+            useCaseModule,
+            *platformModules,
+        )
+    }


### PR DESCRIPTION
## Summary
- add shared DI module with Koin modules for network, database, repositories and use cases
- initialize Koin on Android, iOS and Web with platform specific modules

## Testing
- `./gradlew ktlintCheck detekt test`


------
https://chatgpt.com/codex/tasks/task_e_68a5491d1748832587fe9e0a3a3e9e33