### PR TITLE
feat: add root component with bottom navigation

### DIFF
--- a/shared/app/build.gradle.kts
+++ b/shared/app/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 implementation(compose.foundation)
                 implementation(compose.material3)
                 implementation(libs.decompose)
+                implementation(libs.decompose.compose)
                 implementation(libs.koin.core)
                 implementation(project(":shared:domain"))
                 implementation(project(":shared:di"))

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/App.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/App.kt
@@ -1,36 +1,27 @@
 package net.scoretogether.shared.app
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import net.scoretogether.shared.app.ui.components.AppBottomBar
-import net.scoretogether.shared.app.ui.components.AppBottomBarItem
-import net.scoretogether.shared.app.ui.components.AppTopBar
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import net.scoretogether.shared.app.root.DefaultRootComponent
+import net.scoretogether.shared.app.root.RootContent
 import net.scoretogether.shared.app.ui.theme.AppTheme
 
 @Composable
 fun app() {
     AppTheme {
-        Scaffold(
-            topBar = { AppTopBar(title = "ScoreTogether") },
-            bottomBar = {
-                AppBottomBar(
-                    items =
-                        listOf(
-                            AppBottomBarItem(label = "Home", icon = { Text("\uD83C\uDFE0") }),
-                            AppBottomBarItem(label = "Settings", icon = { Text("\u2699\uFE0F") }),
-                        ),
-                    selectedIndex = 0,
-                    onItemSelected = {},
-                )
-            },
-        ) { innerPadding ->
-            Box(modifier = Modifier.padding(innerPadding)) {
-                // TODO implement app UI
+        val lifecycle = remember { LifecycleRegistry() }
+        val root = remember { DefaultRootComponent(DefaultComponentContext(lifecycle = lifecycle)) }
+        DisposableEffect(Unit) {
+            lifecycle.onCreate()
+            lifecycle.onStart()
+            onDispose {
+                lifecycle.onStop()
+                lifecycle.onDestroy()
             }
         }
+        RootContent(root)
     }
 }

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/discover/DiscoverComponent.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/discover/DiscoverComponent.kt
@@ -1,0 +1,56 @@
+@file:Suppress("FunctionName")
+
+package net.scoretogether.shared.app.discover
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.value.Value
+
+interface DiscoverComponent {
+    val childStack: Value<ChildStack<*, Child>>
+
+    sealed interface Child {
+        data object Stub : Child
+    }
+}
+
+class DefaultDiscoverComponent(
+    componentContext: ComponentContext,
+) : DiscoverComponent,
+    ComponentContext by componentContext {
+    private val navigation = StackNavigation<Unit>()
+
+    override val childStack: Value<ChildStack<Unit, DiscoverComponent.Child>> =
+        childStack<ComponentContext, Unit, DiscoverComponent.Child>(
+            source = navigation,
+            serializer = null,
+            initialStack = { listOf(Unit) },
+            handleBackButton = true,
+            childFactory = { _: Unit, _: ComponentContext -> DiscoverComponent.Child.Stub },
+        )
+}
+
+@Composable
+fun DiscoverContent(component: DiscoverComponent) {
+    Children(stack = component.childStack) { child ->
+        when (child.instance) {
+            DiscoverComponent.Child.Stub -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("Discover screen")
+                }
+            }
+        }
+    }
+}

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/organizer/OrganizerComponent.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/organizer/OrganizerComponent.kt
@@ -1,0 +1,56 @@
+@file:Suppress("FunctionName")
+
+package net.scoretogether.shared.app.organizer
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.value.Value
+
+interface OrganizerComponent {
+    val childStack: Value<ChildStack<*, Child>>
+
+    sealed interface Child {
+        data object Stub : Child
+    }
+}
+
+class DefaultOrganizerComponent(
+    componentContext: ComponentContext,
+) : OrganizerComponent,
+    ComponentContext by componentContext {
+    private val navigation = StackNavigation<Unit>()
+
+    override val childStack: Value<ChildStack<Unit, OrganizerComponent.Child>> =
+        childStack<ComponentContext, Unit, OrganizerComponent.Child>(
+            source = navigation,
+            serializer = null,
+            initialStack = { listOf(Unit) },
+            handleBackButton = true,
+            childFactory = { _: Unit, _: ComponentContext -> OrganizerComponent.Child.Stub },
+        )
+}
+
+@Composable
+fun OrganizerContent(component: OrganizerComponent) {
+    Children(stack = component.childStack) { child ->
+        when (child.instance) {
+            OrganizerComponent.Child.Stub -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text("Organizer screen")
+                }
+            }
+        }
+    }
+}

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/root/RootComponent.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/root/RootComponent.kt
@@ -1,0 +1,54 @@
+package net.scoretogether.shared.app.root
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import net.scoretogether.shared.app.discover.DefaultDiscoverComponent
+import net.scoretogether.shared.app.discover.DiscoverComponent
+import net.scoretogether.shared.app.organizer.DefaultOrganizerComponent
+import net.scoretogether.shared.app.organizer.OrganizerComponent
+
+interface RootComponent {
+    val selectedTab: Value<Tab>
+    val discoverStack: Value<ChildStack<*, DiscoverComponent>>
+    val organizerStack: Value<ChildStack<*, OrganizerComponent>>
+
+    fun onTabSelect(tab: Tab)
+
+    enum class Tab { DISCOVER, ORGANIZER }
+}
+
+class DefaultRootComponent(
+    componentContext: ComponentContext,
+) : RootComponent,
+    ComponentContext by componentContext {
+    private val _selectedTab = MutableValue(RootComponent.Tab.DISCOVER)
+    override val selectedTab: Value<RootComponent.Tab> = _selectedTab
+
+    private val discoverNavigation = StackNavigation<Unit>()
+    override val discoverStack: Value<ChildStack<Unit, DiscoverComponent>> =
+        childStack<ComponentContext, Unit, DiscoverComponent>(
+            source = discoverNavigation,
+            serializer = null,
+            initialStack = { listOf(Unit) },
+            handleBackButton = true,
+            childFactory = { _: Unit, ctx: ComponentContext -> DefaultDiscoverComponent(ctx) },
+        )
+
+    private val organizerNavigation = StackNavigation<Unit>()
+    override val organizerStack: Value<ChildStack<Unit, OrganizerComponent>> =
+        childStack<ComponentContext, Unit, OrganizerComponent>(
+            source = organizerNavigation,
+            serializer = null,
+            initialStack = { listOf(Unit) },
+            handleBackButton = true,
+            childFactory = { _: Unit, ctx: ComponentContext -> DefaultOrganizerComponent(ctx) },
+        )
+
+    override fun onTabSelect(tab: RootComponent.Tab) {
+        _selectedTab.value = tab
+    }
+}

--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/root/RootContent.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/root/RootContent.kt
@@ -1,0 +1,57 @@
+@file:Suppress("FunctionName")
+
+package net.scoretogether.shared.app.root
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import net.scoretogether.shared.app.discover.DiscoverContent
+import net.scoretogether.shared.app.organizer.OrganizerContent
+import net.scoretogether.shared.app.ui.components.AppBottomBar
+import net.scoretogether.shared.app.ui.components.AppBottomBarItem
+
+@Composable
+fun RootContent(
+    component: RootComponent,
+    modifier: Modifier = Modifier,
+) {
+    val selectedTab by component.selectedTab.subscribeAsState()
+
+    Scaffold(
+        bottomBar = {
+            AppBottomBar(
+                items =
+                    listOf(
+                        AppBottomBarItem(label = "Discover", icon = { Text("\uD83D\uDD0D") }),
+                        AppBottomBarItem(label = "Organizer", icon = { Text("\uD83D\uDCC5") }),
+                    ),
+                selectedIndex = selectedTab.ordinal,
+                onItemSelected = { index ->
+                    component.onTabSelect(RootComponent.Tab.values()[index])
+                },
+            )
+        },
+        modifier = modifier,
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding)) {
+            when (selectedTab) {
+                RootComponent.Tab.DISCOVER -> {
+                    Children(stack = component.discoverStack) { child ->
+                        DiscoverContent(child.instance)
+                    }
+                }
+                RootComponent.Tab.ORGANIZER -> {
+                    Children(stack = component.organizerStack) { child ->
+                        OrganizerContent(child.instance)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- setup RootComponent with Discover and Organizer stacks
- add shared BottomBar and hoist tab state
- add stub screens for Discover and Organizer

## Testing
- `./gradlew --no-configuration-cache ktlintCheck detekt`
- `./gradlew --no-configuration-cache test`
- `./gradlew --no-configuration-cache :app-android:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68a5607c964883258ea55bcc892f2c57