### PR TITLE
fix: assign unique keys for root child stacks

### DIFF
--- a/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/root/RootComponent.kt
+++ b/shared/app/src/commonMain/kotlin/net/scoretogether/shared/app/root/RootComponent.kt
@@ -35,6 +35,7 @@ class DefaultRootComponent(
             serializer = null,
             initialStack = { listOf(Unit) },
             handleBackButton = true,
+            key = "DiscoverStack",
             childFactory = { _: Unit, ctx: ComponentContext -> DefaultDiscoverComponent(ctx) },
         )
 
@@ -45,6 +46,7 @@ class DefaultRootComponent(
             serializer = null,
             initialStack = { listOf(Unit) },
             handleBackButton = true,
+            key = "OrganizerStack",
             childFactory = { _: Unit, ctx: ComponentContext -> DefaultOrganizerComponent(ctx) },
         )
 


### PR DESCRIPTION
## Summary
- add explicit keys for Discover and Organizer child stacks to prevent statekeeper collisions

## Testing
- `./gradlew ktlintFormat`
- `./gradlew ktlintCheck detekt`
- `./gradlew test`
- `./gradlew :app-android:assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68a568cd125c8325a73b7c3561f6b9c4