### PR TITLE
feat: add wasm index page

### DIFF
--- a/app-web/src/wasmJsMain/resources/index.html
+++ b/app-web/src/wasmJsMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ScoreTogether</title>
+</head>
+<body>
+  <script type="module">
+    import init, { main } from './app-web.js';
+    init().then(() => main());
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an HTML entrypoint for the WASM web module
- load the generated bundle and invoke `main`

## Testing
- `./gradlew ktlintCheck detekt test` *(fails: required Android SDK installation caused task to be interrupted)*
- `./gradlew :app-web:wasmJsBrowserDevelopmentRun --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68a59dac55388325a11af85718b12a28